### PR TITLE
Add support for filtering a watch action based on label selectors.

### DIFF
--- a/src/DotnetKubernetesClient/IKubernetesClient.cs
+++ b/src/DotnetKubernetesClient/IKubernetesClient.cs
@@ -181,7 +181,7 @@ namespace DotnetKubernetesClient
         /// If the namespace is omitted, all resources on the cluster are watched.
         /// </param>
         /// <param name="cancellationToken">Cancellation-Token.</param>
-        /// <param name="labelSelector">A string, representing an optional label selector for filtering watched objects.</param>
+        /// <param name="labelSelectors">A list of label-selectors to apply to the search.</param>
         /// <typeparam name="TResource">The concrete type of the resource.</typeparam>
         /// <returns>A resource watcher for the given resource.</returns>
         Task<Watcher<TResource>> Watch<TResource>(
@@ -191,7 +191,7 @@ namespace DotnetKubernetesClient
             Action? onClose = null,
             string? @namespace = null,
             CancellationToken cancellationToken = default,
-            params ILabelSelector[] labelSelector)
+            params ILabelSelector[] labelSelectors)
             where TResource : IKubernetesObject<V1ObjectMeta>;
 
         /// <summary>

--- a/src/DotnetKubernetesClient/IKubernetesClient.cs
+++ b/src/DotnetKubernetesClient/IKubernetesClient.cs
@@ -181,6 +181,7 @@ namespace DotnetKubernetesClient
         /// If the namespace is omitted, all resources on the cluster are watched.
         /// </param>
         /// <param name="cancellationToken">Cancellation-Token.</param>
+        /// <param name="labelSelector">A string, representing an optional label selector for filtering watched objects.</param>
         /// <typeparam name="TResource">The concrete type of the resource.</typeparam>
         /// <returns>A resource watcher for the given resource.</returns>
         Task<Watcher<TResource>> Watch<TResource>(
@@ -189,7 +190,35 @@ namespace DotnetKubernetesClient
             Action<Exception>? onError = null,
             Action? onClose = null,
             string? @namespace = null,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            params ILabelSelector[] labelSelector)
+            where TResource : IKubernetesObject<V1ObjectMeta>;
+
+        /// <summary>
+        /// Create a resource watcher on the kubernetes api.
+        /// The resource watcher fires events for resource-events on
+        /// Kubernetes (events: <see cref="WatchEventType"/>.
+        /// </summary>
+        /// <param name="timeout">The timeout which the watcher has (after this timeout, the server will close the connection).</param>
+        /// <param name="onEvent">Action that is called when an event occurs.</param>
+        /// <param name="onError">Action that handles exceptions.</param>
+        /// <param name="onClose">Action that handles closed connections.</param>
+        /// <param name="namespace">
+        /// The namespace to watch for resources (if needed).
+        /// If the namespace is omitted, all resources on the cluster are watched.
+        /// </param>
+        /// <param name="cancellationToken">Cancellation-Token.</param>
+        /// <param name="labelSelector">A string, representing an optional label selector for filtering watched objects.</param>
+        /// <typeparam name="TResource">The concrete type of the resource.</typeparam>
+        /// <returns>A resource watcher for the given resource.</returns>
+        Task<Watcher<TResource>> Watch<TResource>(
+            TimeSpan timeout,
+            Action<WatchEventType, TResource> onEvent,
+            Action<Exception>? onError = null,
+            Action? onClose = null,
+            string? @namespace = null,
+            CancellationToken cancellationToken = default,
+            string? labelSelector = null)
             where TResource : IKubernetesObject<V1ObjectMeta>;
     }
 }

--- a/src/DotnetKubernetesClient/KubernetesClient.cs
+++ b/src/DotnetKubernetesClient/KubernetesClient.cs
@@ -308,8 +308,28 @@ namespace DotnetKubernetesClient
             Action<Exception>? onError = null,
             Action? onClose = null,
             string? @namespace = null,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            params ILabelSelector[] labelSelectors)
             where TResource : IKubernetesObject<V1ObjectMeta>
+            => Watch<TResource>(
+                timeout,
+                onEvent,
+                onError,
+                onClose,
+                @namespace,
+                cancellationToken,
+                string.Join(",", labelSelectors.Select(l => l.ToExpression())));
+
+        /// <inheritdoc />
+        public Task<Watcher<TResource>> Watch<TResource>(
+        TimeSpan timeout,
+        Action<WatchEventType, TResource> onEvent,
+        Action<Exception>? onError = null,
+        Action? onClose = null,
+        string? @namespace = null,
+        CancellationToken cancellationToken = default,
+        string? labelSelector = null)
+        where TResource : IKubernetesObject<V1ObjectMeta>
         {
             var crd = CustomEntityDefinitionExtensions.CreateResourceDefinition<TResource>();
             var result = string.IsNullOrWhiteSpace(@namespace)
@@ -317,6 +337,7 @@ namespace DotnetKubernetesClient
                     crd.Group,
                     crd.Version,
                     crd.Plural,
+                    labelSelector: labelSelector,
                     timeoutSeconds: (int)timeout.TotalSeconds,
                     watch: true,
                     cancellationToken: cancellationToken)
@@ -325,6 +346,7 @@ namespace DotnetKubernetesClient
                     crd.Version,
                     @namespace,
                     crd.Plural,
+                    labelSelector: labelSelector,
                     timeoutSeconds: (int)timeout.TotalSeconds,
                     watch: true,
                     cancellationToken: cancellationToken);


### PR DESCRIPTION
This would resolve #7.

Changes were tested for namespace and cluster-scoped resources on Kubernetes v1.19.5