### PR TITLE
Fixes JsonSerializerOptions Usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+.vs/
 
 # Ci things
 node_modules/

--- a/src/DotnetKubernetesClient/DotnetKubernetesClient.csproj
+++ b/src/DotnetKubernetesClient/DotnetKubernetesClient.csproj
@@ -26,4 +26,10 @@
         <PackageReference Include="KubernetesClient" Version="7.2.19" />
     </ItemGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>DotnetKubernetesClient.Test</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
 </Project>

--- a/src/DotnetKubernetesClient/KubernetesJsonOptions.cs
+++ b/src/DotnetKubernetesClient/KubernetesJsonOptions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Reflection;
+using System.Text.Json;
+using k8s;
+
+#nullable enable
+
+namespace DotnetKubernetesClient
+{
+    internal static class KubernetesJsonOptions
+    {
+        private static readonly Lazy<JsonSerializerOptions?> Lazy = new(GetJsonSerializerOptions);
+
+        public static JsonSerializerOptions? DefaultOptions => Lazy.Value;
+
+        private static JsonSerializerOptions? GetJsonSerializerOptions()
+        {
+            try
+            {
+                // Get the default (and private) KubernetesJson options.
+                var fieldInfo = typeof(KubernetesJson).GetField("JsonSerializerOptions", BindingFlags.Static | BindingFlags.NonPublic);
+                if (fieldInfo != null
+                    && fieldInfo.GetValue(null) is JsonSerializerOptions options)
+                {
+                    return options;
+                }
+            }
+            catch
+            {
+                // Ignored
+            }
+
+            return null;
+        }
+    }
+}

--- a/tests/DotnetKubernetesClient.Test/KubernetesJsonOptions.Test.cs
+++ b/tests/DotnetKubernetesClient.Test/KubernetesJsonOptions.Test.cs
@@ -1,0 +1,16 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace DotnetKubernetesClient.Test
+{
+    public class KubernetesJsonOptionsTest
+    {
+        [Fact]
+        public void DefaultOptions_should_not_return_null()
+        {
+            var result = KubernetesJsonOptions.DefaultOptions;
+
+            result.Should().NotBe(null);
+        }
+    }
+}


### PR DESCRIPTION
This pr prevents the need to annotate every property by using the `JsonSerializerOptions` used by KubernetesJsonOptions internally.

Note the use of reflection to get the non-private field `KubernetesJson.JsonSerializerOptions`. In theory, this should be safe, since a fallback can be used (at the performance hit of needing to re-tokenize the incoming json for a second parse).

IMO, this hack is preferable to coping and pasting from the `k8s` project (since we will use whatever version that the developer has pinned).